### PR TITLE
README fix params phenotype index

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ nextflow run workflows/main.nf \
     --phenotype test_data/phenotype/Phe_linear_covars_mod1.txt \
     --phenolist_file test_data/phenotype/Phe_linear_covars_mod1_phenolist.txt \
     --covarcollist "age,sex" \
+    --sampleidcol renamed_sampleid \
     --regression_method "linear"
 ```
 


### PR DESCRIPTION
I had some problems using the command in README.md, I solved it by using the parameter --sampleidcol renamed_sampleid, according to the column in the phenotype files.
I made this PR to save time to new users 😄.