### PR TITLE
Shapeit conda

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ nextflow run workflows/main.nf \
     --phenotype test_data/phenotype/Phe_linear_covars_mod1.txt \
     --phenolist_file test_data/phenotype/Phe_linear_covars_mod1_phenolist.txt \
     --covarcollist "age,sex" \
+    --sampleidcol renamed_sampleid \
     --regression_method "linear"
 ```
 

--- a/modules/shapeit5_ligate.nf
+++ b/modules/shapeit5_ligate.nf
@@ -26,17 +26,34 @@ process RUN_SHAPEIT5_LIGATE {
     """
     ls -1v *.bcf > list_ligate.${chr}.txt
 
-    ligate_static \\
-    --input list_ligate.${chr}.txt \\
-    --output ${output_prefix}_${chr}.shapeit5_common_ligate.vcf.gz \\
-    --thread ${task.cpus} \\
-    --index \\
-    --log ${output_prefix}_${chr}.shapeit5_common_ligate.log
+    if command -v SHAPEIT5_ligate &> /dev/null; then
+        SHAPEIT5_ligate \\
+        --input list_ligate.${chr}.txt \\
+        --output ${output_prefix}_${chr}.shapeit5_common_ligate.vcf.gz \\
+        --thread ${task.cpus} \\
+        --log ${output_prefix}_${chr}.shapeit5_common_ligate.log
+        bcftools index ${output_prefix}_${chr}.shapeit5_common_ligate.vcf.gz
+
+    else
+        ligate_static \\
+        --input list_ligate.${chr}.txt \\
+        --output ${output_prefix}_${chr}.shapeit5_common_ligate.vcf.gz \\
+        --thread ${task.cpus} \\
+        --index \\
+        --log ${output_prefix}_${chr}.shapeit5_common_ligate.log
+    fi
     """
 
     stub:
     """
     ls -1v *.bcf > list_ligate.${chr}.txt
+
+    echo "SHAPEIT5_ligate \\    
+    --input list_ligate.${chr}.txt \\
+    --output ${output_prefix}_${chr}.shapeit5_common_ligate.vcf.gz \\
+    --thread ${task.cpus} \\
+    --log ${output_prefix}_${chr}.shapeit5_common_ligate.log
+    bcftools index ${output_prefix}_${chr}.shapeit5_common_ligate.vcf.gz"
 
     echo "ligate_static \\
     --input list_ligate.${chr}.txt \\

--- a/modules/shapeit5_phase_common.nf
+++ b/modules/shapeit5_phase_common.nf
@@ -32,15 +32,27 @@ process RUN_SHAPEIT5_PHASE_COMMON {
     """
     echo "# Running SHAPEIT5 Phasing..."
 
-    phase_common_static \\
-    --input ${input_vcf} \\
-    ${ref_vcf_command} \\
-    --map ${genetic_map} \\
-    --output ${output_prefix}_${chr}.chunk_${data[0]}.shapeit5_common.bcf \\
-    --thread ${task.cpus} \\
-    --log ${output_prefix}_${chr}.chunk_${data[0]}.shapeit5_common.log \\
-    ${filter_maf_command} \\
-    --region ${data[1]}
+    if command -v SHAPEIT5_phase_common &> /dev/null; then
+        SHAPEIT5_phase_common \
+        --input ${input_vcf} \
+        ${ref_vcf_command} \
+        --map ${genetic_map} \
+        --output ${output_prefix}_${chr}.chunk_${data[0]}.shapeit5_common.bcf \
+        --thread ${task.cpus} \
+        --log ${output_prefix}_${chr}.chunk_${data[0]}.shapeit5_common.log \
+        ${filter_maf_command} \
+        --region ${data[1]}
+    else
+        phase_common_static \
+        --input ${input_vcf} \
+        ${ref_vcf_command} \
+        --map ${genetic_map} \
+        --output ${output_prefix}_${chr}.chunk_${data[0]}.shapeit5_common.bcf \
+        --thread ${task.cpus} \
+        --log ${output_prefix}_${chr}.chunk_${data[0]}.shapeit5_common.log \
+        ${filter_maf_command} \
+        --region ${data[1]}
+    fi
 
     """
     stub:
@@ -49,9 +61,19 @@ process RUN_SHAPEIT5_PHASE_COMMON {
     """
     echo "# Running SHAPEIT5 Phasing..."
 
-    echo "phase_common_static \\
+    echo "SHAPEIT5_phase_common \\
     --input ${input_vcf} \\
     $ref_vcf_command \\
+    --map ${genetic_map} \\
+    --output ${output_prefix}_${chr}.chunk_${data[0]}.shapeit5_common.bcf \\
+    --thread ${task.cpus} \\
+    --log ${output_prefix}_${chr}.chunk_${data[0]}.shapeit5_common.log \\
+    ${filter_maf_command} \\
+    --region ${data[1]}"
+
+    echo "phase_common_static \\
+    --input ${input_vcf} \\
+    ${ref_vcf_command} \\
     --map ${genetic_map} \\
     --output ${output_prefix}_${chr}.chunk_${data[0]}.shapeit5_common.bcf \\
     --thread ${task.cpus} \\


### PR DESCRIPTION
I've added support for Shapeit5 from Conda. It's called with SHAPEIT5_ligate and SHAPEIT5_phase_common for the RUN_SHAPEIT5_LIGATE and RUN_SHAPEIT_PHASE_COMMON methods, respectively. It still works with the static binary, but as a backup.
SHAPEIT5 can't use the index parameter, so I used bcftools to create the .csi file.
I hope it works better for new users 😄 